### PR TITLE
remove 16_middle_tc2

### DIFF
--- a/maps/2016/16_middle_tc2.pgm
+++ b/maps/2016/16_middle_tc2.pgm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f2101ed939a743413551617c5eceb1f5f02259fec94c4480df96c3cdcbe940b
-size 110039097

--- a/maps/2016/16_middle_tc2.yaml
+++ b/maps/2016/16_middle_tc2.yaml
@@ -1,7 +1,0 @@
-image: 16_middle_tc2.pgm
-resolution: 0.050000
-origin: [-292.000000, -100.000000, 0.000000]
-negate: 0
-occupied_thresh: 0.65
-free_thresh: 0.196
-


### PR DESCRIPTION
運用の際に混乱を招きそうなので, 関連するwaypointsもろとも消し去ることになった.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_maps/20)
<!-- Reviewable:end -->
