### PR TITLE
fix 16_middle_tcall_for_costmap

### DIFF
--- a/maps/2016/16_middle_tcall_for_costmap.pgm
+++ b/maps/2016/16_middle_tcall_for_costmap.pgm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c06f241f33b9932b5fa8bea29e9513983329daa26726f7cb6cfe1b79fefed59d
+oid sha256:af3c40ff0418e549b40b6644e84d6ad5ac7661c3453cda6425dc02e0d9281911
 size 110039097


### PR DESCRIPTION
地図に記録された雑音(通行人？ロボット？)を消した.
2016/11/05の記録走行時のbag fileを確認していたら雑音によってglobal costmapが出ていて, 経路計画が遅延する要因になっていた.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_maps/28)
<!-- Reviewable:end -->
